### PR TITLE
Readme tweaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const action = async context => {
 };
 
 const gifski = {
-	title: 'Export with Gifski',
+	title: 'Export With Gifski',
 	formats: [
 		'gif'
 	],

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const action = async context => {
 };
 
 const gifski = {
-	title: 'Export With Gifski',
+	title: 'Export with Gifski',
 	formats: [
 		'gif'
 	],

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 
 ## Install
 
-In the `Kap` menu, go to `Preferences…`, select the `Plugins` pane, find this plugin, and click `Install`.
+In the `Kap` menu, go to `Preferences…`, select the `Plugins` pane, find this plugin, and toggle it.
 
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -12,4 +12,4 @@ In the `Kap` menu, go to `Preferences…`, select the `Plugins` pane, find this 
 
 ## Usage
 
-In the editor, after recording, select `GIF`, and then `Export with Gifski`.
+In the editor, after recording, select `GIF`, and then `Export With Gifski`.

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# kap-giphy [![Build Status](https://travis-ci.org/wulkano/kap-giphy.svg?branch=master)](https://travis-ci.org/wulkano/kap-giphy)
+# kap-gifski [![Build Status](https://travis-ci.org/wulkano/kap-gifski.svg?branch=master)](https://travis-ci.org/wulkano/kap-gifski)
 
 > [Kap](https://github.com/wulkano/kap) plugin - Export to high-quality GIFs using [Gifski](https://github.com/sindresorhus/Gifski)
 
@@ -12,4 +12,4 @@ In the `Kap` menu, go to `Preferences…`, select the `Plugins` pane, find this 
 
 ## Usage
 
-In the editor, after recording, select `GIF`, and then `Export With Gifski`.
+In the editor, after recording, select `GIF`, and then `Export with Gifski`.


### PR DESCRIPTION
- Lowercased `with` to match the text of the rest of the plugins
- Changed readme title and badges to point to `gifksi` 

Not sure about this part of the readme: 
> find this plugin, and click `Install`.

Since there's no 'install', I was thinking maybe `find this plugin, and toggle it`? 